### PR TITLE
Use __builtin_ctzll as fallback if available

### DIFF
--- a/board.h
+++ b/board.h
@@ -278,6 +278,13 @@ int firstSquare(qword a)
 		: "cc");
 	return (int)res;
 }
+#elif defined(__GNUC__)
+inline
+int firstSquare(qword a)
+{
+    assert(a != 0);
+    return __builtin_ctzll(a);
+}
 #else
 #error not a supported architecture
  // If someone wants to support non-intel architectures, there are some (slower) C versions


### PR DESCRIPTION
This is mostly useful for JavaScript, where none of the inline assembly versions will be available, but it might also be useful for some other obscure platforms.
